### PR TITLE
fix: duplicate path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1
+
+### Fixes
+
+- Remove duplicate path separators that could cause files to not be found.
+
 ## 1.0.0
 
 ### Features

--- a/IONFileViewerLib.podspec
+++ b/IONFileViewerLib.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                   = 'IONFileViewerLib'
-  spec.version                = '1.0.0'
+  spec.version                = '1.0.1'
 
   spec.summary                = 'Library for viewing files in iOS.'
   spec.description            = <<-DESC

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The library supports local files, app assets, and remote URLs.
 `ion-ios-fileviewer` is available through [CocoaPods](https://cocoapods.org). Add this to your Podfile:
 
 ```ruby
-pod 'IONFileViewerLib', '~> 1.0.0'  # Use the latest 1.0.x version
+pod 'IONFileViewerLib', '~> 1.0.1'  # Use the latest 1.0.x version
 ```
 
 ## Quick Start


### PR DESCRIPTION
After doing a similar fix in [filesystem native lib](https://github.com/ionic-team/ion-ios-filesystem/pull/5), adding an equivalent change to the file viewer lib