### PR TITLE
fix: Opening local files without file://

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -19,7 +19,7 @@ jobs:
         run: brew link --overwrite swiftlint || brew install swiftlint
 
       - name: Set up XCode 
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       
       - name: Bundle Install
         run: bundle install

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -25,7 +25,7 @@ jobs:
         run: brew link --overwrite swiftlint || brew install swiftlint
 
       - name: Set up XCode 
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/IONFileViewerLib/IONFLVWManager.swift
+++ b/IONFileViewerLib/IONFLVWManager.swift
@@ -100,7 +100,9 @@ private extension IONFLVWManager {
     
     func prepareLocalFile(atPath filePath: String) throws -> URL {
         guard !filePath.isEmpty else { throw IONFLVWError.emptyFilePath }
-        let filePathToUse = replaceDuplicateSlashes(fromLocalPath: filePath)
+        var filePathToUse = replaceDuplicateSlashes(fromLocalPath: filePath)
+        // add file:// if it doesn't exist - the document / media opening fails if the local file is not a "file://" URI.
+        filePathToUse = filePathToUse.hasPrefix("file://") ? filePathToUse : "file://\(filePathToUse)"
         guard let file = URL(string: filePathToUse) else { throw IONFLVWError.couldNotOpenDocument }
         guard !file.pathExtension.isEmpty else { throw IONFLVWError.missingFileExtension }
         guard fileManager.fileExists(atPath: file.path) else { throw IONFLVWError.fileDoesNotExist(atPath: filePathToUse) }

--- a/IONFileViewerLib/IONFLVWManager.swift
+++ b/IONFileViewerLib/IONFLVWManager.swift
@@ -13,13 +13,7 @@ public class IONFLVWManager {
 
 extension IONFLVWManager: IONFLVWOpenDocumentManager {
     public func openDocumentFromLocalPath(filePath: String, completion: @escaping (() -> Void)) throws {
-        guard !filePath.isEmpty else {
-            throw IONFLVWError.emptyFilePath
-        }
-        let filePathToUse = replaceDuplicateSlashes(fromLocalPath: filePath)
-        guard let file = URL(string: filePathToUse) else { throw IONFLVWError.couldNotOpenDocument }
-        guard !file.pathExtension.isEmpty else { throw IONFLVWError.missingFileExtension }
-        guard fileManager.fileExists(atPath: file.path) else { throw IONFLVWError.fileDoesNotExist(atPath: filePathToUse) }
+        let file = try prepareLocalFile(atPath: filePath)
         
         openDocumentFromLocalPath(file, completion)
     }
@@ -59,10 +53,7 @@ extension IONFLVWManager: IONFLVWOpenDocumentManager {
 
 extension IONFLVWManager: IONFLVWPreviewMediaManager {
     public func previewMediaContentFromLocalPath(filePath: String) throws {
-        guard !filePath.isEmpty else { throw IONFLVWError.emptyFilePath }
-        let filePathToUse = replaceDuplicateSlashes(fromLocalPath: filePath)
-        guard let file = URL(string: filePathToUse) else { throw IONFLVWError.couldNotOpenDocument }
-        guard fileManager.fileExists(atPath: file.path) else { throw IONFLVWError.fileDoesNotExist(atPath: filePathToUse) }
+        let file = try prepareLocalFile(atPath: filePath)
         
         previewMediaContent(file)
     }
@@ -105,6 +96,15 @@ private extension IONFLVWManager {
         
         let resourceURL = URL(fileURLWithPath: resourcePath)
         return resourceURL
+    }
+    
+    func prepareLocalFile(atPath filePath: String) throws -> URL {
+        guard !filePath.isEmpty else { throw IONFLVWError.emptyFilePath }
+        let filePathToUse = replaceDuplicateSlashes(fromLocalPath: filePath)
+        guard let file = URL(string: filePathToUse) else { throw IONFLVWError.couldNotOpenDocument }
+        guard !file.pathExtension.isEmpty else { throw IONFLVWError.missingFileExtension }
+        guard fileManager.fileExists(atPath: file.path) else { throw IONFLVWError.fileDoesNotExist(atPath: filePathToUse) }
+        return file
     }
     
     func replaceDuplicateSlashes(fromLocalPath path: String) -> String {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,10 @@ default_platform(:ios)
 platform :ios do
   desc "Lane to run the unit tests"
   lane :unit_tests do
-    run_tests(scheme: "IONFileViewerLib")
+    run_tests(
+      scheme: "IONFileViewerLib",
+      destination: "platform=iOS Simulator,name=iPhone 17,OS=26.0"
+    )
   end
 
   desc "Code coverage"


### PR DESCRIPTION
## PR Description

The methods to open local files expect a `file://` URI, which is not guaranteed to happen (e.g. [File Transfer](https://github.com/ionic-team/ion-ios-filetransfer) returns a full file path without `file://`).

This PR fixes that by adding `file://` to the local file path if it does not exist.

## Testing

Since there isn't an official release of this native library to test, you may use this capacitor application https://github.com/OS-pedrogustavobilro/issue-cap-file-viewer - and after doing `cap sync` replace the `IONFileViewerLib.xcframework` found in `ios/App/Pods` with the one from obtained from calling `scripts/build_framework.sh` in this repo. You may test before replacing the xcframework (issue should occur, empty screen trying to open pdf / video), and after replacing xcframework (simple pdf is shown, sample video is played)