### PR TITLE
fix: use Xcode15 for release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Link SwiftLint or install it
         run: brew link --overwrite swiftlint || brew install swiftlint
 
-      - name: Set up XCode 
+      - name: Set up XCode (minmum support version)
         run: sudo xcode-select --switch /Applications/Xcode_15.0.app
 
       - name: Set up Ruby

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-release:
     if: github.ref == 'refs/heads/main'
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
         run: brew link --overwrite swiftlint || brew install swiftlint
 
       - name: Set up XCode 
-        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.app
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   post-merge:
     if: contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
## Reasoning

Because Xcode 15 the minimum supported version for our native library - See `README` file.

PR #6 set Xcode 26 for generating the xcframework, but it was breaking break apps on older Xcode versions. 

CI can still use Xcode 26 and latest macos.

## Failed build logs

Refer to logs using `1.0.2` (built with Xcode 26) with OutSystems iOS builds:

- [MABS 10](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=399ca3689748f4d19c1bed8cea525d9550eff0a2&stg=dev)
- [MABS 11.1](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=5732f951d45c596b4b1072278bc7a0e1673a4d00&stg=dev)
- [MABS 11.2](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=2b4200687a06b8799c727d0ef0b116f07ec9afca&stg=dev)